### PR TITLE
fix path-to-regexp dependencies (workaround)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@astrojs/ts-plugin": "^1.10.2",
         "astro": "^4.15.6",
         "dset": "^3.1.4",
-        "path-to-regexp": "^6.3.0",
         "typescript": "^5.5.3"
       }
     },
@@ -2184,7 +2183,7 @@
         "ora": "^8.1.0",
         "p-limit": "^6.1.0",
         "p-queue": "^8.0.1",
-        "path-to-regexp": "6.2.2",
+        "path-to-regexp": "^6.2.2",
         "preferred-pm": "^4.0.0",
         "prompts": "^2.4.2",
         "rehype": "^13.0.1",
@@ -2216,12 +2215,6 @@
       "optionalDependencies": {
         "sharp": "^0.33.3"
       }
-    },
-    "node_modules/astro/node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
-      "license": "MIT"
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@astrojs/ts-plugin": "^1.10.2",
     "astro": "^4.15.6",
     "dset": "^3.1.4",
-    "path-to-regexp": "^6.3.0",
     "typescript": "^5.5.3"
   }
 }


### PR DESCRIPTION
#2 で再び脆弱性のある `path-to-regexp` を復活させてしまったので対処。

Astro v4.15.6 では `path-to-regexp` の依存が `^6.2.2` ではなく `6.2.2` を直接指定して固定されてしまっているのが原因。
近々対応されるっぽいので、一旦依存を直接書き換えて対処。